### PR TITLE
DBに集めたデータを定期的に舐めまわして個人情報掘り出すやつ

### DIFF
--- a/twitter/drain-twitter.rb
+++ b/twitter/drain-twitter.rb
@@ -160,5 +160,7 @@ end
 dt = DrainTwitter.new
 # dt.shed_stream
 # dt.add_user_info("masason")
-dt.main
+loop do
+  dt.main
+end
 # dt.fill_in_column

--- a/twitter/models/pixiver.rb
+++ b/twitter/models/pixiver.rb
@@ -1,0 +1,10 @@
+require 'active_record'
+require 'activerecord-import'
+require 'yaml'
+
+yaml_path = "#{__dir__}/../../config.yml"
+conf = YAML::load_file(yaml_path)
+ActiveRecord::Base.establish_connection(conf["mysql"]["prd"])
+# ActiveRecord::Base.establish_connection($conf["mysql"]["dev"])
+class Pixiver < ActiveRecord::Base
+end

--- a/twitter/models/social_relation.rb
+++ b/twitter/models/social_relation.rb
@@ -1,0 +1,10 @@
+require 'active_record'
+require 'activerecord-import'
+require 'yaml'
+
+yaml_path = "#{__dir__}/../../config.yml"
+conf = YAML::load_file(yaml_path)
+ActiveRecord::Base.establish_connection(conf["mysql"]["prd"])
+# ActiveRecord::Base.establish_connection($conf["mysql"]["dev"])
+class SocialRelation < ActiveRecord::Base
+end

--- a/twitter/sns-matchmaker.rb
+++ b/twitter/sns-matchmaker.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/ruby
+# -*- coding: utf-8 -*-
+#SNSテーブルの情報から他のSNS情報を割り出して登録する
+require_relative 'models/twitterer'
+require_relative 'models/pixiver'
+require_relative 'models/social_relation'
+
+sitename = "pixiv"
+result   = Twitterer.where("website regexp ?", sitename) #.pluck(:website)
+
+ids          = names = []
+pixivers = []
+social_relations = []
+result.each { |site|
+  site  = site.website
+  tw_id = site.id
+  if site =~ /.*id=(\d+)/
+    pixiv_id = $1
+    pixivers << Pixiver.new(
+      id: pixiv_id
+       )
+  elsif site =~ /.*pixiv\.me\/(.*)/
+    pixiv_name = $1
+     pixivers << Pixiver.new(
+      name: pixiv_name
+       )
+  end
+  twid_pxvid_h[tw_id] = pixiv_id
+  social_relations << SocialRelation.new(
+    master_id: xxx, #users.id
+    social_type: xxx, #pixiv
+    social_id: pixiv_id
+  )
+}
+
+# on_duplicat以下各テーブル用に修正する
+Pixiver.import pixivers.to_a, :on_duplicate_key_update => [:screen_name, :name, :description, :website, :location, :icon_path, :posts_count, :favorites_count, :follows_count, :followers_count, :listed_count], :validate => false
+SocialRelation.import social_relations.to_a, :on_duplicate_key_update => [:screen_name, :name, :description, :website, :location, :icon_path, :posts_count, :favorites_count, :follows_count, :followers_count, :listed_count], :validate => false


### PR DESCRIPTION
- social_relations.master_id == users.id?
- だとしたらusersレコードを先に作っておかないとrelationsも作れない
 - users.nameはできれば本名のほうがいいはず→facebookベースでusersレコードも作ったほうがいい？
 - facebookはまだクロール準備的にもハードルが高めなので既にレコード豊富なtwitterのscreen_nameあたりをuser.nameにとりあえず入れとく？
- そうすればmaster_idができて、social_relationsもレコード作れるのでpixiv x twitterとかのrelationがやっとinsertできる